### PR TITLE
Add CPack-based RPM and DEB packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,4 @@ if (HINDER_WITH_TESTS)
     add_subdirectory(tests/queue)
 endif ()
 
+include(cmake/packaging.cmake)

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -1,0 +1,53 @@
+################################################################################
+# CPack packaging configuration
+# Generates RPM and DEB packages for runtime and development components.
+#
+# Runtime component:
+#   RPM: hinder         DEB: libhinder0
+#   Contents: libhinder.so.0, libhinder.so.0.1.0
+#
+# Devel component:
+#   RPM: hinder-devel   DEB: libhinder-dev
+#   Contents: headers, CMake config files
+################################################################################
+
+set(CPACK_PACKAGE_NAME "hinder")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_CONTACT "https://github.com/tonywalker1/hinder")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_DESCRIPTION}")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+
+set(CPACK_COMPONENTS_ALL runtime devel)
+set(CPACK_COMPONENT_RUNTIME_DISPLAY_NAME "hinder Runtime Library")
+set(CPACK_COMPONENT_RUNTIME_DESCRIPTION "Shared library for hinder C++ utilities.")
+set(CPACK_COMPONENT_DEVEL_DISPLAY_NAME "hinder Development Files")
+set(CPACK_COMPONENT_DEVEL_DESCRIPTION "Headers and CMake config files for building against hinder.")
+set(CPACK_COMPONENT_DEVEL_DEPENDS runtime)
+
+################################################################################
+# RPM settings
+################################################################################
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+set(CPACK_RPM_PACKAGE_GROUP "System/Libraries")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_RELEASE "1")
+
+set(CPACK_RPM_RUNTIME_PACKAGE_NAME "hinder")
+set(CPACK_RPM_DEVEL_PACKAGE_NAME "hinder-devel")
+set(CPACK_RPM_DEVEL_PACKAGE_REQUIRES "hinder = ${PROJECT_VERSION}")
+
+################################################################################
+# DEB settings
+################################################################################
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+set(CPACK_DEBIAN_PACKAGE_SECTION "libs")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
+
+set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "libhinder0")
+set(CPACK_DEBIAN_DEVEL_PACKAGE_NAME "libhinder-dev")
+set(CPACK_DEBIAN_DEVEL_PACKAGE_DEPENDS "libhinder0 (= ${PROJECT_VERSION})")
+
+################################################################################
+# Must come last
+################################################################################
+include(CPack)

--- a/doc/contents.md
+++ b/doc/contents.md
@@ -4,6 +4,7 @@
 
 * **[CMake Options:](doc/cmake_options.md)** Set various build options.
 * **[Dependencies:](./doc/dependencies.md)** Everything you need to build this library.
+* **[Packaging:](./doc/packaging.md)** Build and install RPM and DEB system packages.
 
 ## Overviews/Tutorials
 

--- a/doc/doc/packaging.md
+++ b/doc/doc/packaging.md
@@ -1,0 +1,116 @@
+# Packaging
+
+hinder can be packaged as installable system packages (RPM or DEB) using CPack.
+
+## Packages
+
+Two packages are produced, following Linux library naming conventions:
+
+| Package       | Format | Contents                                         |
+|---------------|--------|--------------------------------------------------|
+| `hinder`      | RPM    | `libhinder.so.0`, `libhinder.so.0.1.0`          |
+| `libhinder0`  | DEB    | `libhinder.so.0`, `libhinder.so.0.1.0`          |
+| `hinder-devel`| RPM    | headers under `/usr/include/hinder/`, CMake config files |
+| `libhinder-dev`| DEB   | headers under `/usr/include/hinder/`, CMake config files |
+
+Install the runtime package to run applications linked against hinder. Install the devel package to
+build applications that use hinder.
+
+## Prerequisites
+
+**RPM (Fedora/RHEL/openSUSE):**
+
+```bash
+sudo dnf install rpm-build
+```
+
+**DEB (Debian/Ubuntu):**
+
+```bash
+sudo apt install dpkg-dev
+```
+
+## Quick Build
+
+The helper script configures, builds, and generates both package types:
+
+```bash
+bash scripts/build-packages.sh
+```
+
+Packages are written to `build/packages/` by default. Pass an alternate directory as the first
+argument:
+
+```bash
+bash scripts/build-packages.sh /tmp/hinder-pkgs
+```
+
+## Manual Build
+
+```bash
+# Configure (tests disabled — not needed for packaging)
+cmake -B build/packages -DCMAKE_BUILD_TYPE=Release -DHINDER_WITH_TESTS=OFF
+
+# Build
+cmake --build build/packages -j$(nproc)
+
+# Generate RPM packages
+cd build/packages && cpack -G RPM
+
+# Generate DEB packages
+cd build/packages && cpack -G DEB
+```
+
+## Package Contents
+
+Inspect packages without installing:
+
+```bash
+# RPM
+rpm -qpl build/packages/hinder-0.1.0-1.*.rpm
+rpm -qpl build/packages/hinder-devel-0.1.0-1.*.rpm
+
+# DEB
+dpkg -c build/packages/libhinder0_0.1.0_*.deb
+dpkg -c build/packages/libhinder-dev_0.1.0_*.deb
+```
+
+Expected runtime package contents:
+
+```
+/usr/lib64/libhinder.so.0
+/usr/lib64/libhinder.so.0.1.0
+```
+
+Expected devel package contents:
+
+```
+/usr/include/hinder/...
+/usr/lib64/cmake/hinder/hinderConfig.cmake
+/usr/lib64/cmake/hinder/hinderConfigVersion.cmake
+/usr/lib64/cmake/hinder/hinderTargets.cmake
+```
+
+## Install and Uninstall
+
+**RPM:**
+
+```bash
+# Install
+sudo rpm -ivh build/packages/hinder-0.1.0-1.*.rpm
+sudo rpm -ivh build/packages/hinder-devel-0.1.0-1.*.rpm
+
+# Uninstall
+sudo rpm -e hinder-devel hinder
+```
+
+**DEB:**
+
+```bash
+# Install
+sudo dpkg -i build/packages/libhinder0_0.1.0_*.deb
+sudo dpkg -i build/packages/libhinder-dev_0.1.0_*.deb
+
+# Uninstall
+sudo dpkg -r libhinder-dev libhinder0
+```

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build RPM and DEB packages for hinder.
+#
+# Usage: build-packages.sh [BUILD_DIR]
+#   BUILD_DIR  Optional build directory (default: build/packages)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${1:-${REPO_DIR}/build/packages}"
+
+echo "==> Configuring (BUILD_DIR=${BUILD_DIR})"
+cmake -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DHINDER_WITH_TESTS=OFF \
+    "${REPO_DIR}"
+
+echo "==> Building"
+cmake --build "${BUILD_DIR}" -j"$(nproc)"
+
+echo "==> Generating RPM"
+(cd "${BUILD_DIR}" && cpack -G RPM)
+
+echo "==> Generating DEB"
+(cd "${BUILD_DIR}" && cpack -G DEB)
+
+echo ""
+echo "==> Packages written to: ${BUILD_DIR}"
+find "${BUILD_DIR}" \( -name "*.rpm" -o -name "*.deb" \) | sort | sed 's/^/    /'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,8 +42,12 @@ target_include_directories(hinder
 install(TARGETS hinder
     EXPORT hinderTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT devel
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT runtime
+        NAMELINK_COMPONENT devel
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT runtime
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -51,6 +55,7 @@ install(TARGETS hinder
 install(
     DIRECTORY ${PROJECT_SOURCE_DIR}/include/hinder
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT devel
 )
 
 ################################################################################
@@ -62,6 +67,7 @@ install(EXPORT hinderTargets
     FILE hinderTargets.cmake
     NAMESPACE hinder::
     DESTINATION ${HINDER_CMAKE_CONFIG_DIR}
+    COMPONENT devel
 )
 
 # Generate package config file
@@ -83,4 +89,5 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/hinderConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/hinderConfigVersion.cmake"
     DESTINATION ${HINDER_CMAKE_CONFIG_DIR}
+    COMPONENT devel
 )


### PR DESCRIPTION
## Summary

- Adds `cmake/packaging.cmake` with CPack configuration that generates separate runtime and devel packages for both RPM and DEB formats
- Updates `src/CMakeLists.txt` install() calls with per-artifact component labels; uses `LIBRARY COMPONENT runtime` + `NAMELINK_COMPONENT devel` to correctly split the shared library between packages
- Adds `scripts/build-packages.sh` helper script (configure → build → cpack RPM + DEB)
- Adds `doc/doc/packaging.md` with prerequisites, usage, package contents, and install/uninstall commands
- Links packaging docs from `doc/contents.md`

## Package Layout

| Component | RPM name        | DEB name         | Contents                                        |
|-----------|-----------------|------------------|-------------------------------------------------|
| runtime   | `hinder`        | `libhinder0`     | `libhinder.so.0`, `libhinder.so.0.1.0`         |
| devel     | `hinder-devel`  | `libhinder-dev`  | headers, CMake config files, `libhinder.so`     |

## Test Plan

- [ ] `bash scripts/build-packages.sh` completes without errors
- [ ] `rpm -qpl build/packages/hinder-0.1.0-Linux-runtime.rpm` shows `libhinder.so.0` and `libhinder.so.0.1.0`
- [ ] `rpm -qpl build/packages/hinder-0.1.0-Linux-devel.rpm` shows headers and CMake config files
- [ ] `dpkg -c build/packages/hinder-0.1.0-Linux-runtime.deb` shows the same library files (on a Debian system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)